### PR TITLE
Upgrade p-curve dependencies to 0.13.0

### DIFF
--- a/.github/workflows/jose-b64.yml
+++ b/.github/workflows/jose-b64.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         features:
           -

--- a/.github/workflows/jose-jwa.yml
+++ b/.github/workflows/jose-jwa.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jose-jwe.yml
+++ b/.github/workflows/jose-jwe.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jose-jwk.yml
+++ b/.github/workflows/jose-jwk.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         features:
           # Test no features, individual features and all features.

--- a/.github/workflows/jose-jws.yml
+++ b/.github/workflows/jose-jws.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jose-jwt.yml
+++ b/.github/workflows/jose-jwt.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
         target:
           - thumbv7em-none-eabi
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0 # MSRV
+          - 1.65.0 # MSRV
           - stable
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.63.0
+          toolchain: 1.65.0
           components: clippy
           override: true
           profile: minimal

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [features]
 secret = ["serde", "dep:zeroize", "dep:subtle"]

--- a/jose-b64/README.md
+++ b/jose-b64/README.md
@@ -13,7 +13,7 @@ Base64 utilities for use in JOSE crates.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -40,7 +40,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-b64/badge.svg
 [docs-link]: https://docs.rs/jose-b64/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-b64.yml/badge.svg

--- a/jose-b64/src/serde/secret.rs
+++ b/jose-b64/src/serde/secret.rs
@@ -54,7 +54,7 @@ impl<T: Zeroize, E> DerefMut for Secret<T, E> {
     }
 }
 
-impl<T: Zeroize, U, E> AsRef<U> for Secret<T, E>
+impl<T: Zeroize, U: ?Sized, E> AsRef<U> for Secret<T, E>
 where
     Bytes<T, E>: AsRef<U>,
 {

--- a/jose-b64/src/serde/secret.rs
+++ b/jose-b64/src/serde/secret.rs
@@ -54,7 +54,7 @@ impl<T: Zeroize, E> DerefMut for Secret<T, E> {
     }
 }
 
-impl<T: Zeroize, U: ?Sized, E> AsRef<U> for Secret<T, E>
+impl<T: Zeroize, U, E> AsRef<U> for Secret<T, E>
 where
     Bytes<T, E>: AsRef<U>,
 {

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 serde = { version = "1.0.136", default-features = false, features = ["alloc", "derive"] }

--- a/jose-jwa/README.md
+++ b/jose-jwa/README.md
@@ -15,7 +15,7 @@ in [RFC7518].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-jwa/badge.svg
 [docs-link]: https://docs.rs/jose-jwa/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-jwa.yml/badge.svg

--- a/jose-jwe/Cargo.toml
+++ b/jose-jwe/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwe/README.md
+++ b/jose-jwe/README.md
@@ -15,7 +15,7 @@ in [RFC7516].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-jwe/badge.svg
 [docs-link]: https://docs.rs/jose-jwe/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-jwe.yml/badge.svg

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -31,8 +31,8 @@ jose-jwa = { path = "../jose-jwa" }
 url = { version = "2.2.2", default-features = false, optional = true, features = ["serde"] }
 
 # Internal Dependencies
-p256 = { version = "0.11.1", default-features = false, optional = true, features = ["arithmetic"] }
-p384 = { version = "0.11.1", default-features = false, optional = true, features = ["arithmetic"] }
+p256 = { version = "0.13.0", default-features = false, optional = true, features = ["arithmetic"] }
+p384 = { version = "0.13.0", default-features = false, optional = true, features = ["arithmetic"] }
 zeroize = { version = "1.5.7", default-features = false, optional = true, features = ["alloc"] }
 rsa = { version = "0.7.0-rc.0", default-features = false, optional = true }
 

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [features]
 rcrypto-p256 = ["rcrypto", "dep:p256"]

--- a/jose-jwk/README.md
+++ b/jose-jwk/README.md
@@ -15,7 +15,7 @@ in [RFC7517].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-jwk/badge.svg
 [docs-link]: https://docs.rs/jose-jwk/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-jwk.yml/badge.svg

--- a/jose-jwk/src/crypto/rcrypto/p256.rs
+++ b/jose-jwk/src/crypto/rcrypto/p256.rs
@@ -117,10 +117,7 @@ impl TryFrom<&Ec> for SecretKey {
         }
 
         if let Some(d) = value.d.as_ref() {
-            let field_bytes = p256::NonZeroScalar::try_from(d.as_ref())
-                .map(p256::FieldBytes::from)
-                .map_err(|_| Error::Invalid)?;
-            return Self::from_bytes(&field_bytes).map_err(|_| Error::Invalid);
+            return Self::from_slice(d).map_err(|_| Error::Invalid);
         }
 
         Err(Error::NotPrivate)

--- a/jose-jwk/src/crypto/rcrypto/p256.rs
+++ b/jose-jwk/src/crypto/rcrypto/p256.rs
@@ -95,7 +95,7 @@ impl TryFrom<Ec> for PublicKey {
 impl From<&SecretKey> for Ec {
     fn from(sk: &SecretKey) -> Self {
         let mut key: Self = sk.public_key().into();
-        key.d = Some(sk.to_be_bytes().to_vec().into());
+        key.d = Some(sk.to_bytes().to_vec().into());
         key
     }
 }
@@ -117,7 +117,10 @@ impl TryFrom<&Ec> for SecretKey {
         }
 
         if let Some(d) = value.d.as_ref() {
-            return Self::from_be_bytes(d).map_err(|_| Error::Invalid);
+            let field_bytes = p256::NonZeroScalar::try_from(d.as_ref())
+                .map(p256::FieldBytes::from)
+                .map_err(|_| Error::Invalid)?;
+            return Self::from_bytes(&field_bytes).map_err(|_| Error::Invalid);
         }
 
         Err(Error::NotPrivate)

--- a/jose-jwk/src/crypto/rcrypto/p384.rs
+++ b/jose-jwk/src/crypto/rcrypto/p384.rs
@@ -117,10 +117,7 @@ impl TryFrom<&Ec> for SecretKey {
         }
 
         if let Some(d) = value.d.as_ref() {
-            let field_bytes = p384::NonZeroScalar::try_from(d.as_ref())
-                .map(p384::FieldBytes::from)
-                .map_err(|_| Error::Invalid)?;
-            return Self::from_bytes(&field_bytes).map_err(|_| Error::Invalid);
+            return Self::from_slice(d).map_err(|_| Error::Invalid);
         }
 
         Err(Error::NotPrivate)

--- a/jose-jwk/src/crypto/rcrypto/p384.rs
+++ b/jose-jwk/src/crypto/rcrypto/p384.rs
@@ -95,7 +95,7 @@ impl TryFrom<Ec> for PublicKey {
 impl From<&SecretKey> for Ec {
     fn from(sk: &SecretKey) -> Self {
         let mut key: Self = sk.public_key().into();
-        key.d = Some(sk.to_be_bytes().to_vec().into());
+        key.d = Some(sk.to_bytes().to_vec().into());
         key
     }
 }
@@ -117,7 +117,10 @@ impl TryFrom<&Ec> for SecretKey {
         }
 
         if let Some(d) = value.d.as_ref() {
-            return Self::from_be_bytes(d).map_err(|_| Error::Invalid);
+            let field_bytes = p384::NonZeroScalar::try_from(d.as_ref())
+                .map(p384::FieldBytes::from)
+                .map_err(|_| Error::Invalid)?;
+            return Self::from_bytes(&field_bytes).map_err(|_| Error::Invalid);
         }
 
         Err(Error::NotPrivate)

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 serde = { version = "1.0.136", default-features = false, features = ["alloc", "derive"] }

--- a/jose-jws/README.md
+++ b/jose-jws/README.md
@@ -15,7 +15,7 @@ in [RFC7515].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-jws/badge.svg
 [docs-link]: https://docs.rs/jose-jws/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-jws.yml/badge.svg

--- a/jose-jws/src/compact.rs
+++ b/jose-jws/src/compact.rs
@@ -67,6 +67,6 @@ impl Display for Flattened {
         }
 
         let sign = Base64UrlUnpadded::encode_string(&self.signature.signature);
-        write!(f, "{}.{}.{}", prot, payl, sign)
+        write!(f, "{prot}.{payl}.{sign}")
     }
 }

--- a/jose-jwt/Cargo.toml
+++ b/jose-jwt/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["cryptography", "data-structures", "encoding", "parser-implementat
 keywords = ["json", "jose"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwt/README.md
+++ b/jose-jwt/README.md
@@ -15,7 +15,7 @@ in [RFC7519].
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.63** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
 We may change the MSRV in the future, but it will be accompanied by a minor
 version bump.
@@ -42,7 +42,7 @@ dual licensed as above, without any additional terms or conditions.
 [docs-image]: https://docs.rs/jose-jwt/badge.svg
 [docs-link]: https://docs.rs/jose-jwt/
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.63+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.65+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/300570-formats
 [build-image]: https://github.com/RustCrypto/JOSE/actions/workflows/jose-jwt.yml/badge.svg

--- a/jose/Cargo.toml
+++ b/jose/Cargo.toml
@@ -25,8 +25,8 @@ rand = { version = "0.8.5", default-features = false, optional = true, features 
 
 # Internal, Optional Dependencies (see above features)
 serde_json = { version = "1.0.79", default-features = false, optional = true, features = ["alloc"] }
-p256 = { version = "0.11.1", default-features = false, optional = true, features = ["arithmetic"] }
-p384 = { version = "0.11.1", default-features = false, optional = true, features = ["arithmetic"] }
+p256 = { version = "0.13.0", default-features = false, optional = true, features = ["arithmetic"] }
+p384 = { version = "0.13.0", default-features = false, optional = true, features = ["arithmetic"] }
 rand_core = { version = "0.6.3", default-features = false, optional = true }
 digest = { version = "0.10.3", default-features = false, optional = true }
 sha2 = { version = "0.10.2", default-features = false, optional = true }


### PR DESCRIPTION
If there are any concerns with not requiring `Sized` for the `AsRef` implementation on `Secret`, the alternative is to change `d.as_ref()` to `d.deref().as_ref()`.