### PR TITLE
jose-jwk: rename `rcrypto` to `crypto`

### DIFF
--- a/.github/workflows/jose-jwk.yml
+++ b/.github/workflows/jose-jwk.yml
@@ -56,22 +56,23 @@ jobs:
         features:
           # Test no features, individual features and all features.
           - ""
+          - crypto
+          - p256
+          - p384
+          - rsa
           - url
-          - rcrypto-p256
-          - rcrypto-p384
-          - rcrypto-rsa
-          - url,rcrypto-p256,rcrypto-p384,rcrypto-rsa
+          - p256,p384,rsa,url
 
-          # Test all combinations of rcrypto enablement
-          - rcrypto-p256,rcrypto-p384
-          - rcrypto-p256,rcrypto-rsa
-          - rcrypto-p384,rcrypto-p256
-          - rcrypto-p384,rcrypto-rsa
-          - rcrypto-rsa,rcrypto-p256
-          - rcrypto-rsa,rcrypto-p384
+          # Test all combinations of crypto enablement
+          - p256,p384
+          - p256,rsa
+          - p384,p256
+          - p384,rsa
+          - rsa,p256
+          - rsa,p384
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo test --features=${{ matrix.features }}
+      - run: cargo test --no-default-features --features=${{ matrix.features }}

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -17,14 +17,13 @@ edition = "2021"
 rust-version = "1.65"
 
 [features]
-rcrypto-p256 = ["dep:p256"]
-rcrypto-p384 = ["dep:p384"]
-rcrypto-rsa = ["dep:rsa"]
+default = ["crypto"]
+crypto = ["p256", "p384", "rsa"]
 
 [dependencies]
-serde = { version = "1.0.160", default-features = false, features = ["alloc", "derive"] }
-jose-jwa = { version = "0.1", path = "../jose-jwa" }
 jose-b64 = { version = "0.1", default-features = false, features = ["secret"], path = "../jose-b64" }
+jose-jwa = { version = "0.1", path = "../jose-jwa" }
+serde = { version = "1.0.160", default-features = false, features = ["alloc", "derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies

--- a/jose-jwk/src/crypto/key.rs
+++ b/jose-jwk/src/crypto/key.rs
@@ -24,15 +24,15 @@ pub enum Key {
     Oct(Zeroizing<Box<[u8]>>),
 
     /// An RSA key.
-    #[cfg(feature = "rcrypto-rsa")]
+    #[cfg(feature = "rsa")]
     Rsa(super::Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>),
 
     /// A P-256 key.
-    #[cfg(feature = "rcrypto-p256")]
+    #[cfg(feature = "p256")]
     P256(super::Kind<p256::PublicKey, p256::SecretKey>),
 
     /// A P-384 key.
-    #[cfg(feature = "rcrypto-p384")]
+    #[cfg(feature = "p384")]
     P384(super::Kind<p384::PublicKey, p384::SecretKey>),
 }
 
@@ -41,13 +41,13 @@ impl KeyInfo for Key {
         match self {
             Self::Oct(k) => k.strength(),
 
-            #[cfg(feature = "rcrypto-rsa")]
+            #[cfg(feature = "rsa")]
             Self::Rsa(k) => k.strength(),
 
-            #[cfg(feature = "rcrypto-p256")]
+            #[cfg(feature = "p256")]
             Self::P256(k) => k.strength(),
 
-            #[cfg(feature = "rcrypto-p384")]
+            #[cfg(feature = "p384")]
             Self::P384(k) => k.strength(),
         }
     }
@@ -56,13 +56,13 @@ impl KeyInfo for Key {
         match self {
             Self::Oct(k) => k.is_supported(algo),
 
-            #[cfg(feature = "rcrypto-rsa")]
+            #[cfg(feature = "rsa")]
             Self::Rsa(k) => k.is_supported(algo),
 
-            #[cfg(feature = "rcrypto-p256")]
+            #[cfg(feature = "p256")]
             Self::P256(k) => k.is_supported(algo),
 
-            #[cfg(feature = "rcrypto-p384")]
+            #[cfg(feature = "p384")]
             Self::P384(k) => k.is_supported(algo),
         }
     }
@@ -74,63 +74,63 @@ impl From<Zeroizing<Box<[u8]>>> for Key {
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl From<super::Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>> for Key {
     fn from(value: super::Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>) -> Self {
         Self::Rsa(value)
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl From<rsa::RsaPublicKey> for Key {
     fn from(value: rsa::RsaPublicKey) -> Self {
         Self::Rsa(super::Kind::Public(value))
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl From<rsa::RsaPrivateKey> for Key {
     fn from(value: rsa::RsaPrivateKey) -> Self {
         Self::Rsa(super::Kind::Secret(value))
     }
 }
 
-#[cfg(feature = "rcrypto-p256")]
+#[cfg(feature = "p256")]
 impl From<super::Kind<p256::PublicKey, p256::SecretKey>> for Key {
     fn from(value: super::Kind<p256::PublicKey, p256::SecretKey>) -> Self {
         Self::P256(value)
     }
 }
 
-#[cfg(feature = "rcrypto-p256")]
+#[cfg(feature = "p256")]
 impl From<p256::PublicKey> for Key {
     fn from(value: p256::PublicKey) -> Self {
         Self::P256(super::Kind::Public(value))
     }
 }
 
-#[cfg(feature = "rcrypto-p256")]
+#[cfg(feature = "p256")]
 impl From<p256::SecretKey> for Key {
     fn from(value: p256::SecretKey) -> Self {
         Self::P256(super::Kind::Secret(value))
     }
 }
 
-#[cfg(feature = "rcrypto-p384")]
+#[cfg(feature = "p384")]
 impl From<super::Kind<p384::PublicKey, p384::SecretKey>> for Key {
     fn from(value: super::Kind<p384::PublicKey, p384::SecretKey>) -> Self {
         Self::P384(value)
     }
 }
 
-#[cfg(feature = "rcrypto-p384")]
+#[cfg(feature = "p384")]
 impl From<p384::PublicKey> for Key {
     fn from(value: p384::PublicKey) -> Self {
         Self::P384(super::Kind::Public(value))
     }
 }
 
-#[cfg(feature = "rcrypto-p384")]
+#[cfg(feature = "p384")]
 impl From<p384::SecretKey> for Key {
     fn from(value: p384::SecretKey) -> Self {
         Self::P384(super::Kind::Secret(value))
@@ -143,7 +143,7 @@ impl From<&crate::Oct> for Key {
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl TryFrom<&crate::Rsa> for Key {
     type Error = super::Error;
 
@@ -152,16 +152,16 @@ impl TryFrom<&crate::Rsa> for Key {
     }
 }
 
-#[cfg(any(feature = "rcrypto-p256", feature = "rcrypto-p384"))]
+#[cfg(any(feature = "p256", feature = "p384"))]
 impl TryFrom<&crate::Ec> for Key {
     type Error = super::Error;
 
     fn try_from(value: &crate::Ec) -> Result<Self, Self::Error> {
         match value.crv {
-            #[cfg(feature = "rcrypto-p256")]
+            #[cfg(feature = "p256")]
             crate::EcCurves::P256 => Ok(Self::P256(value.try_into()?)),
 
-            #[cfg(feature = "rcrypto-p384")]
+            #[cfg(feature = "p384")]
             crate::EcCurves::P384 => Ok(Self::P384(value.try_into()?)),
 
             _ => Err(super::Error::Unsupported),
@@ -176,10 +176,10 @@ impl TryFrom<&crate::Key> for Key {
         match value {
             crate::Key::Oct(oct) => Ok(oct.into()),
 
-            #[cfg(feature = "rcrypto-rsa")]
+            #[cfg(feature = "rsa")]
             crate::Key::Rsa(rsa) => rsa.try_into(),
 
-            #[cfg(any(feature = "rcrypto-p256", feature = "rcrypto-p384"))]
+            #[cfg(any(feature = "p256", feature = "p384"))]
             crate::Key::Ec(ec) => ec.try_into(),
 
             _ => Err(super::Error::Unsupported),
@@ -194,19 +194,19 @@ impl From<&Key> for crate::Key {
                 k: oct.to_vec().into(),
             }),
 
-            #[cfg(feature = "rcrypto-rsa")]
+            #[cfg(feature = "rsa")]
             Key::Rsa(kind) => match kind {
                 super::Kind::Public(public) => Self::Rsa(public.into()),
                 super::Kind::Secret(secret) => Self::Rsa(secret.into()),
             },
 
-            #[cfg(feature = "rcrypto-p256")]
+            #[cfg(feature = "p256")]
             Key::P256(kind) => match kind {
                 super::Kind::Public(public) => Self::Ec(public.into()),
                 super::Kind::Secret(secret) => Self::Ec(secret.into()),
             },
 
-            #[cfg(feature = "rcrypto-p384")]
+            #[cfg(feature = "p384")]
             Key::P384(kind) => match kind {
                 super::Kind::Public(public) => Self::Ec(public.into()),
                 super::Kind::Secret(secret) => Self::Ec(secret.into()),

--- a/jose-jwk/src/crypto/kind.rs
+++ b/jose-jwk/src/crypto/kind.rs
@@ -30,7 +30,7 @@ impl<P: KeyInfo, S: KeyInfo> KeyInfo for Kind<P, S> {
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl From<&Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>> for crate::Rsa {
     fn from(value: &Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>) -> Self {
         match value {
@@ -40,7 +40,7 @@ impl From<&Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey>> for crate::Rsa {
     }
 }
 
-#[cfg(feature = "rcrypto-rsa")]
+#[cfg(feature = "rsa")]
 impl TryFrom<&crate::Rsa> for Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey> {
     type Error = super::Error;
 
@@ -53,7 +53,7 @@ impl TryFrom<&crate::Rsa> for Kind<rsa::RsaPublicKey, rsa::RsaPrivateKey> {
     }
 }
 
-#[cfg(feature = "rcrypto-p256")]
+#[cfg(feature = "p256")]
 impl From<&Kind<p256::PublicKey, p256::SecretKey>> for crate::Ec {
     fn from(value: &Kind<p256::PublicKey, p256::SecretKey>) -> Self {
         match value {
@@ -63,7 +63,7 @@ impl From<&Kind<p256::PublicKey, p256::SecretKey>> for crate::Ec {
     }
 }
 
-#[cfg(feature = "rcrypto-p256")]
+#[cfg(feature = "p256")]
 impl TryFrom<&crate::Ec> for Kind<p256::PublicKey, p256::SecretKey> {
     type Error = super::Error;
 
@@ -76,7 +76,7 @@ impl TryFrom<&crate::Ec> for Kind<p256::PublicKey, p256::SecretKey> {
     }
 }
 
-#[cfg(feature = "rcrypto-p384")]
+#[cfg(feature = "p384")]
 impl From<&Kind<p384::PublicKey, p384::SecretKey>> for crate::Ec {
     fn from(value: &Kind<p384::PublicKey, p384::SecretKey>) -> Self {
         match value {
@@ -86,7 +86,7 @@ impl From<&Kind<p384::PublicKey, p384::SecretKey>> for crate::Ec {
     }
 }
 
-#[cfg(feature = "rcrypto-p384")]
+#[cfg(feature = "p384")]
 impl TryFrom<&crate::Ec> for Kind<p384::PublicKey, p384::SecretKey> {
     type Error = super::Error;
 

--- a/jose-jwk/src/crypto/p256.rs
+++ b/jose-jwk/src/crypto/p256.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg(feature = "rcrypto-p256")]
+#![cfg(feature = "p256")]
 
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256::{EncodedPoint, FieldBytes, PublicKey, SecretKey};

--- a/jose-jwk/src/crypto/p384.rs
+++ b/jose-jwk/src/crypto/p384.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg(feature = "rcrypto-p384")]
+#![cfg(feature = "p384")]
 
 use p384::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p384::{EncodedPoint, FieldBytes, PublicKey, SecretKey};

--- a/jose-jwk/src/crypto/rsa.rs
+++ b/jose-jwk/src/crypto/rsa.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Profian Inc. <opensource@profian.com>
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![cfg(feature = "rcrypto-rsa")]
+#![cfg(feature = "rsa")]
 
 use rsa::{
     traits::{PrivateKeyParts, PublicKeyParts},


### PR DESCRIPTION
Removes the `rcrypto-*` prefix from feature names; adds a `crypto` feature which activates `p256`, `p384`, and `rsa`, enabling it by default.