### PR TITLE
Rename `Signing::Null` to `Signing::None`

### DIFF
--- a/jose-jwa/src/lib.rs
+++ b/jose-jwa/src/lib.rs
@@ -93,10 +93,8 @@ pub enum Signing {
     Rs512,
 
     /// No digital signature or MAC performed (Optional)
-    ///
-    /// This variant is renamed as `Null` to avoid colliding with `Option::None`.
     #[serde(rename = "none")]
-    Null,
+    None,
 }
 
 impl fmt::Display for Signing {

--- a/jose-jwk/src/crypto/p256.rs
+++ b/jose-jwk/src/crypto/p256.rs
@@ -6,7 +6,7 @@
 use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p256::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
 
-use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
+use jose_jwa::{Algorithm, Algorithm::Signing, Signing as S};
 
 use super::Error;
 use super::KeyInfo;
@@ -18,7 +18,7 @@ impl KeyInfo for PublicKey {
     }
 
     fn is_supported(&self, algo: &Algorithm) -> bool {
-        matches!(algo, Signing(Es256))
+        matches!(algo, Signing(S::Es256))
     }
 }
 
@@ -28,7 +28,7 @@ impl KeyInfo for SecretKey {
     }
 
     fn is_supported(&self, algo: &Algorithm) -> bool {
-        matches!(algo, Signing(Es256))
+        matches!(algo, Signing(S::Es256))
     }
 }
 

--- a/jose-jwk/src/crypto/p384.rs
+++ b/jose-jwk/src/crypto/p384.rs
@@ -6,7 +6,7 @@
 use p384::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use p384::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
 
-use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
+use jose_jwa::{Algorithm, Algorithm::Signing, Signing as S};
 
 use super::Error;
 use super::KeyInfo;
@@ -18,7 +18,7 @@ impl KeyInfo for PublicKey {
     }
 
     fn is_supported(&self, algo: &Algorithm) -> bool {
-        matches!(algo, Signing(Es384))
+        matches!(algo, Signing(S::Es384))
     }
 }
 
@@ -28,7 +28,7 @@ impl KeyInfo for SecretKey {
     }
 
     fn is_supported(&self, algo: &Algorithm) -> bool {
-        matches!(algo, Signing(Es384))
+        matches!(algo, Signing(S::Es384))
     }
 }
 

--- a/jose-jwk/src/crypto/rsa.rs
+++ b/jose-jwk/src/crypto/rsa.rs
@@ -8,7 +8,7 @@ use rsa::{
     BigUint, RsaPrivateKey, RsaPublicKey,
 };
 
-use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
+use jose_jwa::{Algorithm, Algorithm::Signing, Signing as S};
 
 use super::Error;
 use super::KeyInfo;
@@ -31,12 +31,12 @@ impl KeyInfo for RsaPublicKey {
 
         #[allow(clippy::match_like_matches_macro)]
         match algo {
-            Signing(Rs256) => true,
-            Signing(Rs384) => true,
-            Signing(Rs512) => true,
-            Signing(Ps256) => true,
-            Signing(Ps384) => true,
-            Signing(Ps512) => true,
+            Signing(S::Rs256) => true,
+            Signing(S::Rs384) => true,
+            Signing(S::Rs512) => true,
+            Signing(S::Ps256) => true,
+            Signing(S::Ps384) => true,
+            Signing(S::Ps512) => true,
             _ => false,
         }
     }
@@ -50,12 +50,12 @@ impl KeyInfo for RsaPrivateKey {
     fn is_supported(&self, algo: &Algorithm) -> bool {
         #[allow(clippy::match_like_matches_macro)]
         match (algo, self.strength()) {
-            (Signing(Rs256), 16..) => true,
-            (Signing(Rs384), 24..) => true,
-            (Signing(Rs512), 32..) => true,
-            (Signing(Ps256), 16..) => true,
-            (Signing(Ps384), 24..) => true,
-            (Signing(Ps512), 32..) => true,
+            (Signing(S::Rs256), 16..) => true,
+            (Signing(S::Rs384), 24..) => true,
+            (Signing(S::Rs512), 32..) => true,
+            (Signing(S::Ps256), 16..) => true,
+            (Signing(S::Ps384), 24..) => true,
+            (Signing(S::Ps512), 32..) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
There is no need to avoid conflict with `Option::None` if glob imports are
avoided; "none" is a more accurate term here than "null".

This is a breaking change, but crate usage is low