### PR TITLE
CI: remove `outdated` job

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -43,11 +43,3 @@ jobs:
         with:
             components: rustfmt
       - run: cargo fmt --all -- --check
-
-  outdated:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/install@cargo-outdated
-      - run: cargo outdated --workspace --exit-code 1


### PR DESCRIPTION
Removes the CI job that runs `cargo outdated`.

We get notifications of outdated dependencies via dependabot. No reason for them to break the build.