### PR TITLE
Pin upper version of serde to <1.0.172

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "crypto-bigint"
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -155,13 +155,13 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jose-b64"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64ct",
  "serde",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "jose-jwa"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -184,7 +184,7 @@ version = "0.0.0"
 
 [[package]]
 name = "jose-jwk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jose-b64",
  "jose-jwa",
@@ -199,7 +199,7 @@ dependencies = [
 
 [[package]]
 name = "jose-jws"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "jose-b64",
  "jose-jwa",
@@ -230,9 +230,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
@@ -340,18 +340,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -406,15 +406,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -425,18 +425,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -445,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.97"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "spin"
@@ -494,9 +494,9 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -532,9 +532,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"

--- a/jose-b64/CHANGELOG.md
+++ b/jose-b64/CHANGELOG.md
@@ -4,5 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2023-08-19)
+### Changed
+- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])
+
+[#55]: https://github.com/RustCrypto/JOSE/pull/55
+[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
+
 ## 0.1.0 (2023-05-20)
 - Initial release

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jose-b64"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Base64 utilities for use in JOSE crates"

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -21,8 +21,9 @@ serde = ["dep:serde"]
 base64ct = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies
-serde = { version = "1.0.160", default-features = false, optional = true, features = ["alloc", "derive"] }
 zeroize = { version = "1.6.0", default-features = false, optional = true, features = ["alloc", "serde"] }
+# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0.160, <1.0.172", default-features = false, optional = true, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false, optional = true, features = ["alloc"] }
 subtle = { version = "2.5.0", default-features = false, optional = true }
 

--- a/jose-jwa/CHANGELOG.md
+++ b/jose-jwa/CHANGELOG.md
@@ -4,5 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2023-08-19)
+### Changed
+- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])
+
+[#55]: https://github.com/RustCrypto/JOSE/pull/55
+[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
+
 ## 0.1.0 (2023-05-20)
 - Initial release

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -17,7 +17,8 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-serde = { version = "1.0.160", default-features = false, features = ["alloc", "derive"] }
+# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.96"

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jose-jwa"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/jose-jwk/CHANGELOG.md
+++ b/jose-jwk/CHANGELOG.md
@@ -4,5 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2023-08-19)
+### Changed
+- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])
+
+[#55]: https://github.com/RustCrypto/JOSE/pull/55
+[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
+
 ## 0.1.0 (2023-05-20)
 - Initial release

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -23,7 +23,8 @@ crypto = ["p256", "p384", "rsa"]
 [dependencies]
 jose-b64 = { version = "0.1", default-features = false, features = ["secret"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
-serde = { version = "1.0.160", default-features = false, features = ["alloc", "derive"] }
+# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jose-jwk"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """

--- a/jose-jws/CHANGELOG.md
+++ b/jose-jws/CHANGELOG.md
@@ -4,5 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 (2023-08-19)
+### Changed
+- Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])
+
+[#55]: https://github.com/RustCrypto/JOSE/pull/55
+[serde-rs/serde#2538]: https://github.com/serde-rs/serde/issues/2538
+
 ## 0.1.0 (2023-05-20)
 - Initial release

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -20,7 +20,8 @@ rust-version = "1.65"
 jose-b64 = { version = "0.1", default-features = false, features = ["json"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
 jose-jwk = { version = "0.1", default-features = false, path = "../jose-jwk" }
-serde = { version = "1.0.160", default-features = false, features = ["alloc", "derive"] }
+# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jose-jws"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """


### PR DESCRIPTION
`serde v1.0.172` and later include pre-compiled binaries which is a security hazard. So until the decision gets reverted, I believe it's worth to pin upper version of `serde`. This approach may cause issues if a different crate in someone's dependency tree will depend on a post-1.0.172 version of `serde`, but I think this issue is small enough when compared to the security concerns. Also, a number of other crates in the ecosystem follow this approach, so we are not alone.

More information and discussion about the `serde` change can be found in https://github.com/serde-rs/serde/issues/2538.