### PR TITLE
Set min version of serde to 1.0.185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,18 +425,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/jose-b64/CHANGELOG.md
+++ b/jose-b64/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2023-08-21)
+### Changed
+- Set min version of `serde` to 1.0.184 ([#56])
+
+[#56]: https://github.com/RustCrypto/JOSE/pull/56
+
 ## 0.1.1 (2023-08-19)
 ### Changed
 - Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])

--- a/jose-b64/CHANGELOG.md
+++ b/jose-b64/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 (2023-08-21)
 ### Changed
-- Set min version of `serde` to 1.0.184 ([#56])
+- Set min version of `serde` to 1.0.185 ([#56])
 
 [#56]: https://github.com/RustCrypto/JOSE/pull/56
 

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -22,7 +22,7 @@ base64ct = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 zeroize = { version = "1.6.0", default-features = false, optional = true, features = ["alloc", "serde"] }
-serde = { version = "1.0.184", default-features = false, optional = true, features = ["alloc", "derive"] }
+serde = { version = "1.0.185", default-features = false, optional = true, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false, optional = true, features = ["alloc"] }
 subtle = { version = "2.5.0", default-features = false, optional = true }
 

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -22,8 +22,7 @@ base64ct = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies
 zeroize = { version = "1.6.0", default-features = false, optional = true, features = ["alloc", "serde"] }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.160, <1.0.172", default-features = false, optional = true, features = ["alloc", "derive"] }
+serde = { version = "1.0.184", default-features = false, optional = true, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false, optional = true, features = ["alloc"] }
 subtle = { version = "2.5.0", default-features = false, optional = true }
 

--- a/jose-jwa/CHANGELOG.md
+++ b/jose-jwa/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2023-08-21)
+### Changed
+- Set min version of `serde` to 1.0.184 ([#56])
+
+[#56]: https://github.com/RustCrypto/JOSE/pull/56
+
 ## 0.1.1 (2023-08-19)
 ### Changed
 - Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])

--- a/jose-jwa/CHANGELOG.md
+++ b/jose-jwa/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 (2023-08-21)
 ### Changed
-- Set min version of `serde` to 1.0.184 ([#56])
+- Set min version of `serde` to 1.0.185 ([#56])
 
 [#56]: https://github.com/RustCrypto/JOSE/pull/56
 

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.96"

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -17,8 +17,7 @@ edition = "2021"
 rust-version = "1.65"
 
 [dependencies]
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.96"

--- a/jose-jwk/CHANGELOG.md
+++ b/jose-jwk/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2023-08-21)
+### Changed
+- Set min version of `serde` to 1.0.184 ([#56])
+
+[#56]: https://github.com/RustCrypto/JOSE/pull/56
+
 ## 0.1.1 (2023-08-19)
 ### Changed
 - Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])

--- a/jose-jwk/CHANGELOG.md
+++ b/jose-jwk/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 (2023-08-21)
 ### Changed
-- Set min version of `serde` to 1.0.184 ([#56])
+- Set min version of `serde` to 1.0.185 ([#56])
 
 [#56]: https://github.com/RustCrypto/JOSE/pull/56
 

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -23,7 +23,7 @@ crypto = ["p256", "p384", "rsa"]
 [dependencies]
 jose-b64 = { version = "0.1", default-features = false, features = ["secret"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
-serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -23,8 +23,7 @@ crypto = ["p256", "p384", "rsa"]
 [dependencies]
 jose-b64 = { version = "0.1", default-features = false, features = ["secret"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["alloc"] }
 
 # optional dependencies

--- a/jose-jws/CHANGELOG.md
+++ b/jose-jws/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2023-08-21)
+### Changed
+- Set min version of `serde` to 1.0.184 ([#56])
+
+[#56]: https://github.com/RustCrypto/JOSE/pull/56
+
 ## 0.1.1 (2023-08-19)
 ### Changed
 - Pin upper version of `serde` to <1.0.172 to work around [serde-rs/serde#2538] ([#55])

--- a/jose-jws/CHANGELOG.md
+++ b/jose-jws/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.2 (2023-08-21)
 ### Changed
-- Set min version of `serde` to 1.0.184 ([#56])
+- Set min version of `serde` to 1.0.185 ([#56])
 
 [#56]: https://github.com/RustCrypto/JOSE/pull/56
 

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -20,7 +20,7 @@ rust-version = "1.65"
 jose-b64 = { version = "0.1", default-features = false, features = ["json"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
 jose-jwk = { version = "0.1", default-features = false, path = "../jose-jwk" }
-serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -20,8 +20,7 @@ rust-version = "1.65"
 jose-b64 = { version = "0.1", default-features = false, features = ["json"], path = "../jose-b64" }
 jose-jwa = { version = "0.1", path = "../jose-jwa" }
 jose-jwk = { version = "0.1", default-features = false, path = "../jose-jwk" }
-# Pin upper version of serde to work around https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0.160, <1.0.172", default-features = false, features = ["alloc", "derive"] }
+serde = { version = "1.0.184", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0.96", default-features = false }
 rand_core = { version = "0.6.4", default-features = false }
 


### PR DESCRIPTION
In 1.0.184 `serde` was [un-blobbed](https://github.com/serde-rs/serde/releases/tag/v1.0.184). To prevent accidental pulling of the blobbed versions 1.0.185 will be used as a min version (1.0.184 is not used because of https://github.com/serde-rs/serde/issues/2591).

Relevant PR: #55