### PR TITLE
Make RSA PrivateKey conversion symmetric

### DIFF
--- a/jose-jwk/tests/jwk.rs
+++ b/jose-jwk/tests/jwk.rs
@@ -132,7 +132,7 @@ mod rfc7517 {
                     "qi":"GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
                     "alg":"RS256",
                     "kid":"2011-04-29"
-                }
+                },
             ]
         });
 
@@ -306,10 +306,7 @@ mod rfc7517 {
         #[cfg(feature = "rsa")]
         if let Key::Rsa(key) = &jwk.keys[1].key {
             let pk = ::rsa::RsaPrivateKey::try_from(key).unwrap();
-            // FIXME: work around the serialization asymmetry.
-            let mut k: Rsa = pk.into();
-            k.prv.as_mut().unwrap().opt = key.prv.as_ref().unwrap().opt.clone();
-            assert_eq!(key, &k);
+            assert_eq!(key, &pk.into());
         } else {
             unreachable!()
         }


### PR DESCRIPTION
I noticed that the RSA PrivateKey conversion was not symmetric. This adds the missing value when converting from `&RsaPrivateKey` to `Rsa`. I haven't implemented the ["oth"](https://www.rfc-editor.org/rfc/rfc7518#section-6.3.2.7) since parameter since I have no use for it at the moment.