### PR TITLE
jose-jws: remove broken `url` feature

### DIFF
--- a/jose-jws/src/head.rs
+++ b/jose-jws/src/head.rs
@@ -27,11 +27,6 @@ pub struct Protected {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub crit: Option<Vec<String>>,
 
-    /// RFC 8555 Section 6.4.1
-    #[cfg(feature = "url")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub url: Option<url::Url>,
-
     /// RFC 8555 Section 6.5.2
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub nonce: Option<Bytes>,
@@ -52,9 +47,6 @@ impl Default for Protected {
             nonce: None,
             b64: true,
             oth: Unprotected::default(),
-
-            #[cfg(feature = "url")]
-            url: None,
         }
     }
 }
@@ -66,11 +58,6 @@ pub struct Unprotected {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub alg: Option<Signing>,
 
-    /// RFC 7515 Section 4.1.2
-    #[cfg(feature = "url")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub jku: Option<url::Url>,
-
     /// RFC 7515 Section 4.1.3
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub jwk: Option<Jwk>,
@@ -78,11 +65,6 @@ pub struct Unprotected {
     /// RFC 7515 Section 4.1.4
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub kid: Option<String>,
-
-    /// RFC 7515 Section 4.1.5
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    #[cfg(feature = "url")]
-    pub x5u: Option<url::Url>,
 
     /// RFC 7515 Section 4.1.6
     #[serde(skip_serializing_if = "Option::is_none", default)]


### PR DESCRIPTION
It was never actually declared properly in Cargo.toml and therefore never worked (and therefore this is not actually a breaking change), but also the code behind the feature does not otherwise compile, even if a proper `url` optional dependency is added.