### PR TITLE
feat(jwk): add ext, iat, nbf, ext and revoked to key params

### DIFF
--- a/jose-jwk/src/lib.rs
+++ b/jose-jwk/src/lib.rs
@@ -28,7 +28,7 @@ mod key;
 mod prm;
 
 pub use key::*;
-pub use prm::{Class, Operations, Parameters, Thumbprint};
+pub use prm::{Class, Operations, Parameters, RevocationReason, Revoked, Thumbprint};
 
 pub use jose_b64;
 pub use jose_jwa;

--- a/jose-jwk/src/prm.rs
+++ b/jose-jwk/src/prm.rs
@@ -45,6 +45,55 @@ pub struct Parameters {
     /// The X.509 thumbprint associated with this key.
     #[serde(flatten)]
     pub x5t: Thumbprint,
+
+    /// Whether the key is extractable.
+    ///
+    /// This parameter is defined by the [W3C Web Cryptography API].
+    ///
+    /// [W3C Web Cryptography API]: https://www.w3.org/TR/WebCryptoAPI/
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ext: Option<bool>,
+
+    /// Time when this key was issued.
+    ///
+    /// Expressed as Seconds Since the Epoch per [RFC 7519].
+    ///
+    /// This parameter is defined in [OpenID Federation 1.0, Section 8.7.2].
+    ///
+    /// [RFC 7519]: https://datatracker.ietf.org/doc/html/rfc7519
+    /// [OpenID Federation 1.0, Section 8.7.2]: https://openid.github.io/federation/main.html#section-8.7.2
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub iat: Option<i64>,
+
+    /// Time before which the key MUST NOT be considered valid.
+    ///
+    /// Expressed as Seconds Since the Epoch per [RFC 7519].
+    ///
+    /// This parameter is defined in [OpenID Federation 1.0, Section 8.7.2].
+    ///
+    /// [RFC 7519]: https://datatracker.ietf.org/doc/html/rfc7519
+    /// [OpenID Federation 1.0, Section 8.7.2]: https://openid.github.io/federation/main.html#section-8.7.2
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub nbf: Option<i64>,
+
+    /// Expiration time after which the key MUST NOT be considered valid.
+    ///
+    /// Expressed as Seconds Since the Epoch per [RFC 7519].
+    ///
+    /// This parameter is defined in [OpenID Federation 1.0, Section 8.7.2].
+    ///
+    /// [RFC 7519]: https://datatracker.ietf.org/doc/html/rfc7519
+    /// [OpenID Federation 1.0, Section 8.7.2]: https://openid.github.io/federation/main.html#section-8.7.2
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub exp: Option<i64>,
+
+    /// Revoked key properties.
+    ///
+    /// This parameter is defined in [OpenID Federation 1.0, Section 8.7.2].
+    ///
+    /// [OpenID Federation 1.0, Section 8.7.2]: https://openid.github.io/federation/main.html#section-8.7.2
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub revoked: Option<Revoked>,
 }
 
 impl<T: Into<Algorithm>> From<T> for Parameters {
@@ -103,4 +152,53 @@ pub struct Thumbprint {
     /// An X.509 thumbprint (SHA-2 256).
     #[serde(skip_serializing_if = "Option::is_none", rename = "x5t#S256", default)]
     pub s256: Option<Bytes<[u8; 32]>>,
+}
+
+/// Revoked key properties.
+///
+/// This type is defined in [OpenID Federation 1.0, Section 8.7.2].
+///
+/// [OpenID Federation 1.0, Section 8.7.2]: https://openid.github.io/federation/main.html#section-8.7.2
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Revoked {
+    /// Time when the key was revoked or must be considered revoked.
+    ///
+    /// Expressed as Seconds Since the Epoch per [RFC 7519].
+    ///
+    /// [RFC 7519]: https://datatracker.ietf.org/doc/html/rfc7519
+    pub revoked_at: i64,
+
+    /// The reason for the key revocation.
+    ///
+    /// The reason values are defined in [OpenID Federation 1.0, Section 8.7.3].
+    ///
+    /// [OpenID Federation 1.0, Section 8.7.3]: https://openid.github.io/federation/main.html#section-8.7.3
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<RevocationReason>,
+}
+
+/// Revocation reason for a key.
+///
+/// These reasons are inspired by Section 5.3.1 of [RFC 5280] and defined
+/// in [OpenID Federation 1.0, Section 8.7.3].
+///
+/// [RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280#section-5.3.1
+/// [OpenID Federation 1.0, Section 8.7.3]: https://openid.github.io/federation/main.html#section-8.7.3
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RevocationReason {
+    /// General or unspecified reason for the key status change.
+    #[serde(rename = "unspecified")]
+    Unspecified,
+
+    /// The private key is believed to have been compromised.
+    #[serde(rename = "compromised")]
+    Compromised,
+
+    /// The key is no longer active.
+    #[serde(rename = "superseded")]
+    Superseded,
+
+    /// A federation MAY specify and utilize additional reasons depending on the trust or security framework in use.
+    #[serde(untagged)]
+    Other(String),
 }

--- a/jose-jwk/tests/jwk.rs
+++ b/jose-jwk/tests/jwk.rs
@@ -544,4 +544,80 @@ mod rfc8037 {
         assert_eq!(jwk, serde_json::from_value(val.clone()).unwrap());
         assert_eq!(val, serde_json::to_value(jwk).unwrap());
     }
+
+    // From https://openid.net/specs/openid-federation-1_0.html#name-federation-historical-keys-res
+    // With replaced key types for brevity
+    #[test]
+    fn openid() {
+        let val = serde_json::json!({"keys":
+        [
+            {
+                "kty": "OKP",
+                "crv": "X448",
+                "x": "PreoKbDNIPW8_AtZm2_sz22kYnEHvbDU80W0MCfYuXL8PjT7QjKhPKcG3LV67D2uB73BxnvzNgk",
+                "kid": "2HnoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMEEs",
+                "iat": 1661151600,
+                "exp": 1677052800
+            },
+            {
+                "kty":"OKP",
+                "crv":"X25519",
+                "x":"3p7bfXt9wbTTW2HC7OQ1Nz-DQ8hbeGdNrfx-FG-IK08",
+                "kid": "8KnoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMJJr",
+                "iat": 1647932400,
+                "exp": 1663830000,
+                "revoked": {
+                  "revoked_at": 1661151600,
+                  "reason": "compromised",
+                }
+            }
+        ]});
+        let jwks = JwkSet {
+            keys: vec![
+                Jwk {
+                    key: Key::Okp(Okp {
+                        crv: OkpCurves::X448,
+                        d: None,
+                        x: vec![
+                            62, 183, 168, 41, 176, 205, 32, 245, 188, 252, 11, 89, 155, 111, 236,
+                            207, 109, 164, 98, 113, 7, 189, 176, 212, 243, 69, 180, 48, 39, 216,
+                            185, 114, 252, 62, 52, 251, 66, 50, 161, 60, 167, 6, 220, 181, 122,
+                            236, 61, 174, 7, 189, 193, 198, 123, 243, 54, 9,
+                        ]
+                        .into(),
+                    }),
+                    prm: Parameters {
+                        kid: Some("2HnoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMEEs".to_string()),
+                        iat: Some(1661151600),
+                        exp: Some(1677052800),
+                        ..Default::default()
+                    },
+                },
+                Jwk {
+                    key: Key::Okp(Okp {
+                        crv: OkpCurves::X25519,
+                        d: None,
+                        x: vec![
+                            222, 158, 219, 125, 123, 125, 193, 180, 211, 91, 97, 194, 236, 228, 53,
+                            55, 63, 131, 67, 200, 91, 120, 103, 77, 173, 252, 126, 20, 111, 136,
+                            43, 79,
+                        ]
+                        .into(),
+                    }),
+                    prm: Parameters {
+                        kid: Some("8KnoFS3YnC9tjiCaivhWLVUJ3AxwGGz_98uRFaqMJJr".to_string()),
+                        iat: Some(1647932400),
+                        exp: Some(1663830000),
+                        revoked: Some(Revoked {
+                            revoked_at: 1661151600,
+                            reason: Some(RevocationReason::Compromised),
+                        }),
+                        ..Default::default()
+                    },
+                },
+            ],
+        };
+        assert_eq!(jwks, serde_json::from_value(val.clone()).unwrap());
+        assert_eq!(val, serde_json::to_value(jwks).unwrap());
+    }
 }


### PR DESCRIPTION
Closes https://github.com/RustCrypto/JOSE/issues/93

The registry https://www.iana.org/assignments/jose/jose.xhtml#web-key-parameters contains these, so it makes sense to add support for these.