### PR TITLE
Bump RustCrypto dependencies and move them to the workspace Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,16 @@
 version = 4
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
@@ -16,76 +22,116 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base16ct"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b59d472eab27ade8d770dcb11da7201c11234bef9f82ce7aa517be028d462b"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cmov"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
 
 [[package]]
 name = "const-oid"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.0-rc.4"
+version = "0.7.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c069823f41bdc75e99546bfd59eb1ed27d69dc720e5c949fe502b82926f8448"
+checksum = "96dacf199529fb801ae62a9aafdc01b189e9504c0d1ee1512a4c16bcd8666a93"
 dependencies = [
+ "cpubits",
+ "ctutils",
  "hybrid-array",
  "num-traits",
- "rand_core",
- "serdect 0.4.1",
+ "rand_core 0.10.0",
+ "serdect 0.4.2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "crypto-primes"
-version = "0.7.0-pre.1"
+version = "0.7.0-pre.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae744b9f528151f8c440cf67498f24d2d1ac0ab536b5ce7b1f87a7a5961bd1c1"
+checksum = "6081ce8b60c0e533e2bba42771b94eb6149052115f4179744d5779883dc98583"
 dependencies = [
  "crypto-bigint",
  "libm",
- "rand_core",
+ "rand_core 0.10.0",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+dependencies = [
+ "cmov",
+ "subtle",
 ]
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.8"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7050e8041c28720851f7db83183195b6acf375bb7bb28e3b86f0fe6cbd69459d"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -94,97 +140,275 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4aae35a0fcbe22ff1be50fe96df72002d5a4a6fb4aae9193cf2da0daa36da2"
+checksum = "285743a676ccb6b3e116bc14cc69319b957867930ae9c4822f8e0f54509d7243"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0-rc.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.13"
+version = "0.14.0-rc.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b95fd42abd85018a59f5dbe05551e9eed19edfd1182a415cd98f90ca5af1422"
+checksum = "bde7860544606d222fd6bd6d9f9a0773321bf78072a637e1d560a058c0031978"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct 1.0.0",
  "crypto-bigint",
+ "crypto-common",
  "digest",
- "ff",
- "group",
  "hex-literal",
  "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ff"
-version = "0.14.0-pre.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42dd26f5790eda47c1a2158ea4120e32c35ddc9a7743c98a292accc01b54ef3"
-dependencies = [
- "rand_core",
- "subtle",
-]
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "group"
-version = "0.14.0-pre.0"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6a0b2dd4b981b1ae9e3e6830ab146771f3660d31d57bafd9018805a91b0f1"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "ff",
- "rand_core",
- "subtle",
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
-name = "hex-literal"
-version = "1.0.0"
+name = "hashbrown"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex-literal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
+
+[[package]]
+name = "hmac"
+version = "0.13.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.0"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe39a812f039072707ce38020acbab2f769087952eddd9e2b890f37654b2349"
+checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
 dependencies = [
+ "subtle",
  "typenum",
  "zeroize",
 ]
 
 [[package]]
-name = "idna"
-version = "0.4.0"
+name = "icu_collections"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jose-b64"
@@ -207,7 +431,17 @@ dependencies = [
 
 [[package]]
 name = "jose-jwe"
-version = "0.1.0-pre"
+version = "0.2.0-pre"
+dependencies = [
+ "getrandom",
+ "jose-b64",
+ "jose-jwa",
+ "jose-jwk",
+ "rand_core 0.9.5",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
 
 [[package]]
 name = "jose-jwk"
@@ -234,38 +468,85 @@ dependencies = [
 name = "jose-jws"
 version = "0.2.0-pre"
 dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "hmac",
  "jose-b64",
  "jose-jwa",
  "jose-jwk",
- "rand_core",
+ "k256",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.9.5",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2",
+ "signature",
 ]
 
 [[package]]
 name = "jose-jwt"
-version = "0.1.0-pre"
-
-[[package]]
-name = "k256"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#aba09809dd4e0c4f591ffa7285c77165f8e509bd"
+version = "0.2.0-pre"
 dependencies = [
- "cfg-if",
- "elliptic-curve",
+ "jose-b64",
+ "jose-jwa",
+ "jose-jwe",
+ "jose-jwk",
+ "jose-jws",
+ "serde",
+ "serde_json",
+ "zeroize",
 ]
 
 [[package]]
-name = "libm"
-version = "0.2.15"
+name = "k256"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "83da23da11f0b5db6f23d9280a84b3a33a746aa43ebb9270d6b445991da9cee3"
+dependencies = [
+ "cpubits",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-traits"
@@ -278,134 +559,202 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#aba09809dd4e0c4f591ffa7285c77165f8e509bd"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "018bfbb86e05fd70a83e985921241035ee09fcd369c4a2c3680b389a01d2ad28"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
  "primefield",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#aba09809dd4e0c4f591ffa7285c77165f8e509bd"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c91df688211f5957dbe2ab599dcbcaade8d6d3cdc15c5b350d350d7d07ce423"
 dependencies = [
+ "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
  "primefield",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "p521"
-version = "0.14.0-pre.9"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#aba09809dd4e0c4f591ffa7285c77165f8e509bd"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de6cd9451de522549d36cc78a1b45a699a3d55a872e8ea0c8f0318e502d99e2c"
 dependencies = [
- "base16ct 0.2.0",
+ "base16ct 1.0.0",
+ "ecdsa",
  "elliptic-curve",
  "primefield",
  "primeorder",
+ "sha2",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e58fab693c712c0d4e88f8eb3087b6521d060bcaf76aeb20cb192d809115ba"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.6"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53e5d0804fa4070b1b2a5b320102f2c1c094920a7533d5d87c2630609bcbd34"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
  "der",
  "spki",
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primefield"
-version = "0.14.0-pre.4"
-source = "git+https://github.com/RustCrypto/elliptic-curves.git#aba09809dd4e0c4f591ffa7285c77165f8e509bd"
+version = "0.14.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93401c13cc7ff24684571cfca9d3cf9ebabfaf3d4b7b9963ade41ec54da196b5"
 dependencies = [
  "crypto-bigint",
- "ff",
- "rand_core",
+ "crypto-common",
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.14.0-pre.7"
+version = "0.14.0-rc.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af12dd34fc62d04416de85af032f4595369437fb7b0143d36ae60cecaf5cdddf"
+checksum = "a0c5c8a39bcd764bfedf456e8d55e115fe86dda3e0f555371849f2a41cbc9706"
 dependencies = [
  "elliptic-curve",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.9.3"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rfc6979"
+version = "0.5.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
+dependencies = [
+ "hmac",
+ "subtle",
+]
 
 [[package]]
 name = "rsa"
-version = "0.10.0-rc.6"
+version = "0.10.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c09fc7922fb8b7de31cc809df908e30e0ed46eb33046c6e1e438ef8ec3466b"
+checksum = "6fb9fd8c1edd9e6a2693623baf0fe77ff05ce022a5d7746900ffc38a15c233de"
 dependencies = [
  "const-oid",
  "crypto-bigint",
  "crypto-primes",
  "digest",
- "rand_core",
+ "rand_core 0.10.0",
  "signature",
- "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.15"
+name = "rustcrypto-ff"
+version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "c5db129183b2c139d7d87d08be57cba626c715789db17aec65c8866bfd767d1f"
+dependencies = [
+ "rand_core 0.10.0",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c4b1463f274a3ff6fb2f44da43e576cb9424367bd96f185ead87b52fe00523"
+dependencies = [
+ "rand_core 0.10.0",
+ "rustcrypto-ff",
+ "subtle",
+]
 
 [[package]]
 name = "sec1"
-version = "0.8.0-rc.9"
+version = "0.8.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e67a3c9fb9a8f065af9fa30d65812fcc16a66cbf911eff1f6946957ce48f16"
+checksum = "7a2400ed44a13193820aa528a19f376c3843141a8ce96ff34b11104cc79763f2"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct 1.0.0",
+ "ctutils",
  "der",
  "hybrid-array",
  "subtle",
@@ -413,19 +762,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -434,14 +799,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -456,23 +822,40 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ef0e35b322ddfaecbc60f34ab448e157e48531288ee49fafbb053696b8ffe2"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
 dependencies = [
- "base16ct 0.3.0",
+ "base16ct 1.0.0",
  "serde",
 ]
 
 [[package]]
-name = "signature"
-version = "3.0.0-rc.3"
+name = "sha2"
+version = "0.11.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39195ff4c0dc41c93e123825ca1f0d11b856df8b26d5fe140a522355632c4345"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.10.0",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spki"
@@ -485,6 +868,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,9 +881,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -502,64 +891,297 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
+name = "synstructure"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
- "tinyvec_macros",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
+name = "tinystr"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-normalization"
-version = "0.1.22"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,46 @@ members = [
     "jose-jwt",
 ]
 
+[workspace.package]
+edition = "2024"
+version = "0.2.0-pre"
+rust-version = "1.85"
+authors = ["RustCrypto Developers"]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/RustCrypto/JOSE"
+
+[workspace.dependencies]
+# Internal workspace crates
+jose-b64 = { path = "./jose-b64", features = ["secret", "json"] }
+jose-jwa = { path = "./jose-jwa" }
+jose-jwe = { path = "./jose-jwe" }
+jose-jwk = { path = "./jose-jwk" }
+jose-jws = { path = "./jose-jws" }
+jose-jwt = { path = "./jose-jwt" }
+
+# External dependencies
+base64ct = { version = "1.8", default-features = false, features = ["alloc"] }
+ecdsa = { version = "0.17.0-rc.16", default-features = false, features = ["der", "algorithm", "hazmat"] }
+elliptic-curve = { version = "0.14.0-rc.28", default-features = false, features = ["arithmetic", "sec1"] }
+hmac = { version = "0.13.0-rc.5", default-features = false }
+k256 = { version = "0.14.0-rc.7", default-features = false, features = ["arithmetic", "ecdsa"] }
+p256 = { version = "0.14.0-rc.7", default-features = false, features = ["arithmetic", "ecdsa"] }
+p384 = { version = "0.14.0-rc.7", default-features = false, features = ["arithmetic", "ecdsa"] }
+p521 = { version = "0.14.0-rc.7", default-features = false, features = ["arithmetic", "ecdsa"] }
+rand_core = { version = "0.9", default-features = false }
+rsa = { version = "0.10.0-rc.16", default-features = false }
+serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
+serde_json = { version = "1.0.96", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.11.0-rc.5", default-features = false, features = ["oid"] }
+signature = { version = "3.0.0-rc.4", default-features = false, features = ["digest"] }
+url = { version = "2.4.1", default-features = false, features = ["serde"] }
+zeroize = { version = "1.8.1", default-features = false, features = ["alloc", "serde"] }
+
+# Optional dependencies
+getrandom = { version = "0.4", default-features = false }
+subtle = { version = "2.6", default-features = false }
+serdect = { version = "0.2", default-features = false, features = ["alloc"] }
+
 [profile.dev]
 opt-level = 2
 
@@ -19,9 +59,3 @@ jose-jwe = { path = "./jose-jwe" }
 jose-jwk = { path = "./jose-jwk" }
 jose-jws = { path = "./jose-jws" }
 jose-jwt = { path = "./jose-jwt" }
-
-primefield = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-k256       = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p256       = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p384       = { git = "https://github.com/RustCrypto/elliptic-curves.git" }
-p521       = { git = "https://github.com/RustCrypto/elliptic-curves.git" }

--- a/jose-b64/Cargo.toml
+++ b/jose-b64/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "jose-b64"
-version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = "Base64 utilities for use in JOSE crates"
 documentation = "https://docs.rs/jose-b64"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-b64"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
 keywords = ["json", "jose"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 secret = ["serde", "dep:zeroize", "dep:subtle"]
@@ -19,13 +20,13 @@ json = ["serde", "dep:serde_json"]
 serde = ["dep:serde"]
 
 [dependencies]
-base64ct = { version = "1.8.0", default-features = false, features = ["alloc"] }
+base64ct = { workspace = true }
 
 # optional dependencies
-zeroize = { version = "1.8.1", default-features = false, optional = true, features = ["alloc", "serde"] }
-serde = { version = "1.0.185", default-features = false, optional = true, features = ["alloc", "derive"] }
-serde_json = { version = "1.0.96", default-features = false, optional = true, features = ["alloc"] }
-subtle = { version = "2.5.0", default-features = false, optional = true }
+zeroize = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+subtle = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwa/Cargo.toml
+++ b/jose-jwa/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jose-jwa"
-version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -10,18 +9,20 @@ RFC7518
 """
 documentation = "https://docs.rs/jose-jwa"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-jwa"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
-keywords = ["json", "jose"]
+keywords = ["json", "jose", "jwa"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.96"
+serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwe/Cargo.toml
+++ b/jose-jwe/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jose-jwe"
-version = "0.1.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -10,12 +9,40 @@ RFC7516
 """
 documentation = "https://docs.rs/jose-jwe"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-jwe"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
-keywords = ["json", "jose"]
+keywords = ["json", "jose", "jwe", "encryption"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+# Recommended algorithms (includes all recommended algorithms from RFC 7518)
+recommended = ["rand"]
+
+# Random number generation support
+rand = ["dep:rand_core", "dep:getrandom"]
+
+[dependencies]
+jose-b64 = { workspace = true }
+jose-jwa = { workspace = true }
+jose-jwk = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Random number generation
+rand_core = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true }
+
+zeroize = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwk/Cargo.toml
+++ b/jose-jwk/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jose-jwk"
-version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -10,12 +9,14 @@ RFC7517
 """
 documentation = "https://docs.rs/jose-jwk"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-jwk"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
-keywords = ["json", "jose"]
+keywords = ["json", "jose", "jwk"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["crypto"]
@@ -23,29 +24,29 @@ crypto = ["p256", "p384", "p521", "k256", "rsa"]
 legacy = ["dep:base64ct", "dep:elliptic-curve", "dep:serde_json", "dep:serdect", "dep:subtle"]
 
 [dependencies]
-jose-b64 = { version = "=0.2.0-pre", default-features = false, features = ["secret"] }
-jose-jwa = { version = "=0.2.0-pre" }
-serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-zeroize = { version = "1.8.1", default-features = false, features = ["alloc"] }
+jose-b64 = { workspace = true }
+jose-jwa = { workspace = true }
+serde = { workspace = true }
+zeroize = { workspace = true }
 
 # optional dependencies
-p256 = { version = "0.14.0-pre.9", default-features = false, optional = true, features = ["arithmetic"] }
-p384 = { version = "0.14.0-pre.9", default-features = false, optional = true, features = ["arithmetic"] }
-p521 = { version = "0.14.0-pre.9", default-features = false, optional = true, features = ["arithmetic"] }
-k256 = { version = "0.14.0-pre.9", default-features = false, optional = true, features = ["arithmetic"] }
-rsa = { version = "0.10.0-rc.6", default-features = false, optional = true }
-url = { version = "2.4.1", default-features = false, optional = true, features = ["serde"] }
+p256 = { workspace = true, optional = true }
+p384 = { workspace = true, optional = true }
+p521 = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true }
+rsa = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 
 # legacy dependencies
-base64ct = { version = "1", optional = true, default-features = false, features = ["alloc"] }
-elliptic-curve = { version = "0.14.0-rc.4", optional = true, default-features = false, features = ["arithmetic", "sec1"] }
-serdect = { version = "0.2", optional = true, default-features = false, features = ["alloc"] }
-serde_json = { version = "1.0.121", optional = true, default-features = false, features = ["alloc"] }
-subtle = { version = "2.6", optional = true, default-features = false }
+base64ct = { workspace = true, optional = true }
+elliptic-curve = { workspace = true, optional = true }
+serdect = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+subtle = { workspace = true, optional = true }
 
 [dev-dependencies]
-elliptic-curve = { version = "0.14.0-rc.4", default-features = false, features = ["dev"] }
-serde_json = "1.0.121"
+elliptic-curve = { workspace = true, features = ["dev"] }
+serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwk/src/crypto/k256.rs
+++ b/jose-jwk/src/crypto/k256.rs
@@ -3,8 +3,8 @@
 
 #![cfg(feature = "k256")]
 
-use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use k256::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
+use k256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
+use k256::{FieldBytes, PublicKey, Sec1Point, SecretKey};
 
 use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
 
@@ -39,7 +39,7 @@ impl KeyInfo for SecretKey {
 
 impl From<&PublicKey> for Ec {
     fn from(pk: &PublicKey) -> Self {
-        let ep = pk.to_encoded_point(false);
+        let ep = pk.to_sec1_point(false);
 
         Self {
             crv: EcCurves::P256K,
@@ -77,8 +77,8 @@ impl TryFrom<&Ec> for PublicKey {
         x.copy_from_slice(&value.x);
         y.copy_from_slice(&value.y);
 
-        let ep = EncodedPoint::from_affine_coordinates(&x, &y, false);
-        Option::from(Self::from_encoded_point(&ep)).ok_or(Error::Invalid)
+        let ep = Sec1Point::from_affine_coordinates(&x, &y, false);
+        Option::from(Self::from_sec1_point(&ep)).ok_or(Error::Invalid)
     }
 }
 

--- a/jose-jwk/src/crypto/p256.rs
+++ b/jose-jwk/src/crypto/p256.rs
@@ -3,8 +3,8 @@
 
 #![cfg(feature = "p256")]
 
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use p256::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
+use p256::{FieldBytes, PublicKey, Sec1Point, SecretKey};
 
 use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
 
@@ -39,7 +39,7 @@ impl KeyInfo for SecretKey {
 
 impl From<&PublicKey> for Ec {
     fn from(pk: &PublicKey) -> Self {
-        let ep = pk.to_encoded_point(false);
+        let ep = pk.to_sec1_point(false);
 
         Self {
             crv: EcCurves::P256,
@@ -77,8 +77,8 @@ impl TryFrom<&Ec> for PublicKey {
         x.copy_from_slice(&value.x);
         y.copy_from_slice(&value.y);
 
-        let ep = EncodedPoint::from_affine_coordinates(&x, &y, false);
-        Option::from(Self::from_encoded_point(&ep)).ok_or(Error::Invalid)
+        let ep = Sec1Point::from_affine_coordinates(&x, &y, false);
+        Option::from(Self::from_sec1_point(&ep)).ok_or(Error::Invalid)
     }
 }
 

--- a/jose-jwk/src/crypto/p384.rs
+++ b/jose-jwk/src/crypto/p384.rs
@@ -3,8 +3,8 @@
 
 #![cfg(feature = "p384")]
 
-use p384::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use p384::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
+use p384::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
+use p384::{FieldBytes, PublicKey, Sec1Point, SecretKey};
 
 use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
 
@@ -39,7 +39,7 @@ impl KeyInfo for SecretKey {
 
 impl From<&PublicKey> for Ec {
     fn from(pk: &PublicKey) -> Self {
-        let ep = pk.to_encoded_point(false);
+        let ep = pk.to_sec1_point(false);
 
         Self {
             crv: EcCurves::P384,
@@ -77,8 +77,8 @@ impl TryFrom<&Ec> for PublicKey {
         x.copy_from_slice(&value.x);
         y.copy_from_slice(&value.y);
 
-        let ep = EncodedPoint::from_affine_coordinates(&x, &y, false);
-        Option::from(Self::from_encoded_point(&ep)).ok_or(Error::Invalid)
+        let ep = Sec1Point::from_affine_coordinates(&x, &y, false);
+        Option::from(Self::from_sec1_point(&ep)).ok_or(Error::Invalid)
     }
 }
 

--- a/jose-jwk/src/crypto/p521.rs
+++ b/jose-jwk/src/crypto/p521.rs
@@ -3,8 +3,8 @@
 
 #![cfg(feature = "p521")]
 
-use p521::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use p521::{EncodedPoint, FieldBytes, PublicKey, SecretKey};
+use p521::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
+use p521::{FieldBytes, PublicKey, Sec1Point, SecretKey};
 
 use jose_jwa::{Algorithm, Algorithm::Signing, Signing::*};
 
@@ -39,7 +39,7 @@ impl KeyInfo for SecretKey {
 
 impl From<&PublicKey> for Ec {
     fn from(pk: &PublicKey) -> Self {
-        let ep = pk.to_encoded_point(false);
+        let ep = pk.to_sec1_point(false);
 
         Self {
             crv: EcCurves::P521,
@@ -77,8 +77,8 @@ impl TryFrom<&Ec> for PublicKey {
         x.copy_from_slice(&value.x);
         y.copy_from_slice(&value.y);
 
-        let ep = EncodedPoint::from_affine_coordinates(&x, &y, false);
-        Option::from(Self::from_encoded_point(&ep)).ok_or(Error::Invalid)
+        let ep = Sec1Point::from_affine_coordinates(&x, &y, false);
+        Option::from(Self::from_sec1_point(&ep)).ok_or(Error::Invalid)
     }
 }
 

--- a/jose-jwk/src/legacy.rs
+++ b/jose-jwk/src/legacy.rs
@@ -18,8 +18,8 @@ use core::{
 use elliptic_curve::{
     AffinePoint, Curve, CurveArithmetic, Error, FieldBytes, FieldBytesSize, PublicKey, Result,
     SecretKey,
-    sec1::{Coordinates, EncodedPoint, ModulusSize, ValidatePublicKey},
-    sec1::{FromEncodedPoint, ToEncodedPoint},
+    sec1::{Coordinates, ModulusSize, Sec1Point, ValidatePublicKey},
+    sec1::{FromSec1Point, ToSec1Point},
 };
 use serdect::serde::{Deserialize, Serialize, de, ser};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -105,14 +105,14 @@ impl JwkEcKey {
     pub fn to_public_key<C>(&self) -> Result<PublicKey<C>>
     where
         C: CurveArithmetic + JwkParameters,
-        AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+        AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
         FieldBytesSize<C>: ModulusSize,
     {
         PublicKey::from_sec1_bytes(self.to_encoded_point::<C>()?.as_bytes())
     }
 
-    /// Create a JWK from a SEC1 [`EncodedPoint`].
-    pub fn from_encoded_point<C>(point: &EncodedPoint<C>) -> Option<Self>
+    /// Create a JWK from a [`Sec1Point`].
+    pub fn from_encoded_point<C>(point: &Sec1Point<C>) -> Option<Self>
     where
         C: Curve + JwkParameters,
         FieldBytesSize<C>: ModulusSize,
@@ -128,8 +128,8 @@ impl JwkEcKey {
         }
     }
 
-    /// Get the public key component of this JWK as a SEC1 [`EncodedPoint`].
-    pub fn to_encoded_point<C>(&self) -> Result<EncodedPoint<C>>
+    /// Get the public key component of this JWK as a [`Sec1Point`].
+    pub fn to_encoded_point<C>(&self) -> Result<Sec1Point<C>>
     where
         C: Curve + JwkParameters,
         FieldBytesSize<C>: ModulusSize,
@@ -140,7 +140,7 @@ impl JwkEcKey {
 
         let x = decode_base64url_fe::<C>(&self.x)?;
         let y = decode_base64url_fe::<C>(&self.y)?;
-        Ok(EncodedPoint::<C>::from_affine_coordinates(&x, &y, false))
+        Ok(Sec1Point::<C>::from_affine_coordinates(&x, &y, false))
     }
 
     /// Decode a JWK into a [`SecretKey`].
@@ -207,7 +207,7 @@ where
 impl<C> From<SecretKey<C>> for JwkEcKey
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     fn from(sk: SecretKey<C>) -> JwkEcKey {
@@ -218,7 +218,7 @@ where
 impl<C> From<&SecretKey<C>> for JwkEcKey
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     fn from(sk: &SecretKey<C>) -> JwkEcKey {
@@ -233,7 +233,7 @@ where
 impl<C> TryFrom<JwkEcKey> for PublicKey<C>
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     type Error = Error;
@@ -246,7 +246,7 @@ where
 impl<C> TryFrom<&JwkEcKey> for PublicKey<C>
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     type Error = Error;
@@ -259,7 +259,7 @@ where
 impl<C> From<PublicKey<C>> for JwkEcKey
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     fn from(pk: PublicKey<C>) -> JwkEcKey {
@@ -270,11 +270,11 @@ where
 impl<C> From<&PublicKey<C>> for JwkEcKey
 where
     C: CurveArithmetic + JwkParameters,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
+    AffinePoint<C>: FromSec1Point<C> + ToSec1Point<C>,
     FieldBytesSize<C>: ModulusSize,
 {
     fn from(pk: &PublicKey<C>) -> JwkEcKey {
-        Self::from_encoded_point::<C>(&pk.to_encoded_point(false)).expect("JWK encoding error")
+        Self::from_encoded_point::<C>(&pk.to_sec1_point(false)).expect("JWK encoding error")
     }
 }
 

--- a/jose-jws/Cargo.toml
+++ b/jose-jws/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jose-jws"
-version = "0.2.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -10,20 +9,47 @@ RFC7515
 """
 documentation = "https://docs.rs/jose-jws"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-jws"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
-keywords = ["json", "jose"]
+keywords = ["json", "jose", "jws"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+hmac = ["dep:hmac", "dep:sha2"]
+rsa = ["dep:rsa", "dep:sha2", "dep:signature"]
+ecdsa = ["dep:ecdsa", "dep:sha2", "dep:signature", "dep:elliptic-curve", "p256", "p384", "p521"]
+p256 = ["dep:p256"]
+p384 = ["dep:p384"]
+p521 = ["dep:p521"]
+k256 = ["ecdsa", "dep:k256"]
 
 [dependencies]
-jose-b64 = { version = "=0.2.0-pre", default-features = false, features = ["json"] }
-jose-jwa = { version = "=0.2.0-pre" }
-jose-jwk = { version = "=0.2.0-pre", default-features = false }
-serde = { version = "1.0.185", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "1.0.96", default-features = false }
-rand_core = { version = "0.9", default-features = false }
+jose-b64 = { workspace = true }
+jose-jwa = { workspace = true }
+jose-jwk = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+rand_core = { workspace = true }
+
+# Optional crypto dependencies
+hmac = { workspace = true, optional = true }
+ecdsa = { workspace = true, optional = true }
+elliptic-curve = { workspace = true, optional = true }
+p256 = { workspace = true, optional = true }
+p384 = { workspace = true, optional = true }
+p521 = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true }
+rsa = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+signature = { workspace = true, optional = true }
+
+[dev-dependencies]
+rand_core = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/jose-jwt/Cargo.toml
+++ b/jose-jwt/Cargo.toml
@@ -1,6 +1,5 @@
 [package]
 name = "jose-jwt"
-version = "0.1.0-pre"
 authors = ["RustCrypto Developers"]
 license = "Apache-2.0 OR MIT"
 description = """
@@ -10,12 +9,47 @@ RFC7519
 """
 documentation = "https://docs.rs/jose-jwt"
 homepage = "https://github.com/RustCrypto/JOSE/tree/master/jose-jwt"
-repository = "https://github.com/RustCrypto/JOSE"
+repository.workspace = true
 categories = ["cryptography", "data-structures", "encoding", "parser-implementations"]
-keywords = ["json", "jose"]
+keywords = ["json", "jose", "jwt"]
 readme = "README.md"
-edition = "2024"
-rust-version = "1.85"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[features]
+default = []
+
+# HMAC algorithm support - delegated to jose-jws
+hmac = ["jose-jws/hmac"]
+
+# RSA algorithm support - delegated to jose-jws
+rsa = ["jose-jws/rsa"]
+
+# ECDSA algorithm support - delegated to jose-jws
+ecdsa = ["jose-jws/ecdsa"]
+
+# ES256K (secp256k1) algorithm support - delegated to jose-jws
+k256 = ["jose-jws/k256"]
+
+# Allow "none" algorithm - DISABLED BY DEFAULT for security
+allow-none = []
+
+[dependencies]
+jose-b64 = { workspace = true }
+jose-jwa = { workspace = true }
+jose-jwe = { workspace = true }
+jose-jwk = { workspace = true }
+jose-jws = { workspace = true }
+
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+zeroize = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
I started working on the JWT stuff for https://github.com/RustCrypto/JOSE/issues/24

Step 1 for me was to bump all the versions of RustCrypto dependencies, `rand` etc.

Questions:
- I moved them all to the top level Cargo.toml for the workspace because it was easier for me to manage but let me know if I should undo that.
- I also changed the `elliptic-curves` dependencies to point at crates.io instead of GitHub. I can also undo that but it feels weird to me to have `elliptic-curves` pull from crates.io and other crates (from the same repo) pull from git directly. I think they should all pull from the same place (all from the GitHub repo or all from crates.io)